### PR TITLE
Add working setup screen

### DIFF
--- a/HEG Schedule.xcodeproj/project.pbxproj
+++ b/HEG Schedule.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		222C3DC42662D39E00CF0E12 /* VPlanItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222C3DC32662D39E00CF0E12 /* VPlanItem.swift */; };
 		223214012662C2AA0038CA07 /* VPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223214002662C2AA0038CA07 /* VPlan.swift */; };
 		22503F7F265EAE4000254DC7 /* FeedKit in Frameworks */ = {isa = PBXBuildFile; productRef = 22503F7E265EAE4000254DC7 /* FeedKit */; };
+		22524E482781CDE700DDFE7D /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22524E472781CDE700DDFE7D /* UserSettings.swift */; };
 		225E81BB26653E8B002A4E9E /* Liquid in Frameworks */ = {isa = PBXBuildFile; productRef = 225E81BA26653E8B002A4E9E /* Liquid */; };
 		2273229F266FD8DF00B1900C /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 225FBAE3266F8B2F00F5F4CD /* WidgetKit.framework */; };
 		227322A0266FD8DF00B1900C /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 225FBAE5266F8B2F00F5F4CD /* SwiftUI.framework */; };
@@ -30,6 +31,7 @@
 		22A97F57266BE1A000A0E2CC /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 22A97F56266BE1A000A0E2CC /* Settings.bundle */; };
 		22BBE36D26B876A500AF41D6 /* SwiftUIRefresh in Frameworks */ = {isa = PBXBuildFile; productRef = 22BBE36C26B876A500AF41D6 /* SwiftUIRefresh */; };
 		22CC80252663EBC00059FADD /* VPlanRender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CC80242663EBC00059FADD /* VPlanRender.swift */; };
+		22D5B69E2780B2590047B672 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D5B69D2780B2590047B672 /* SettingsScreen.swift */; };
 		22EA2B2B265E5BB0008E0EC6 /* News.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EA2B2A265E5BB0008E0EC6 /* News.swift */; };
 		22FB6808266030050017FEE6 /* NewsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FB6807266030050017FEE6 /* NewsItem.swift */; };
 		22FD601A2677942200BF02BF /* Timetable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD60192677942200BF02BF /* Timetable.swift */; };
@@ -74,6 +76,7 @@
 		222C3DC32662D39E00CF0E12 /* VPlanItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPlanItem.swift; sourceTree = "<group>"; };
 		223214002662C2AA0038CA07 /* VPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPlan.swift; sourceTree = "<group>"; };
 		22503F71265EA56300254DC7 /* HEG Schedule.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "HEG Schedule.entitlements"; sourceTree = "<group>"; };
+		22524E472781CDE700DDFE7D /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		225FBAE3266F8B2F00F5F4CD /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		225FBAE5266F8B2F00F5F4CD /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		2273229E266FD8DF00B1900C /* HEG-WidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "HEG-WidgetsExtension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -87,6 +90,7 @@
 		22746777266AC74B00093235 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
 		22A97F56266BE1A000A0E2CC /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		22CC80242663EBC00059FADD /* VPlanRender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPlanRender.swift; sourceTree = "<group>"; };
+		22D5B69D2780B2590047B672 /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		22EA2B2A265E5BB0008E0EC6 /* News.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = News.swift; sourceTree = "<group>"; };
 		22FB6807266030050017FEE6 /* NewsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsItem.swift; sourceTree = "<group>"; };
 		22FD60192677942200BF02BF /* Timetable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timetable.swift; sourceTree = "<group>"; };
@@ -146,11 +150,13 @@
 				2212AFE9265D853E00002FC9 /* ContentView.swift */,
 				2212AFFC265DA20600002FC9 /* Home.swift */,
 				2212AFFA265D8A6400002FC9 /* Nav.swift */,
+				22D5B69D2780B2590047B672 /* SettingsScreen.swift */,
 				22FB68062660298F0017FEE6 /* News */,
 				2212AFEB265D854300002FC9 /* Assets.xcassets */,
 				2212AFF0265D854300002FC9 /* Info.plist */,
 				2212AFED265D854300002FC9 /* Preview Content */,
 				22A97F56266BE1A000A0E2CC /* Settings.bundle */,
+				22524E472781CDE700DDFE7D /* UserSettings.swift */,
 			);
 			path = "HEG Schedule";
 			sourceTree = "<group>";
@@ -350,6 +356,7 @@
 				223214012662C2AA0038CA07 /* VPlan.swift in Sources */,
 				227322A9266FD8E300B1900C /* HEG_Widgets.intentdefinition in Sources */,
 				2212AFEA265D853E00002FC9 /* ContentView.swift in Sources */,
+				22D5B69E2780B2590047B672 /* SettingsScreen.swift in Sources */,
 				22746778266AC74B00093235 /* Loader.swift in Sources */,
 				222C3DC42662D39E00CF0E12 /* VPlanItem.swift in Sources */,
 				22FB6808266030050017FEE6 /* NewsItem.swift in Sources */,
@@ -359,6 +366,7 @@
 				2212AFFD265DA20600002FC9 /* Home.swift in Sources */,
 				22746773266AC6D000093235 /* LoaderView.swift in Sources */,
 				22EA2B2B265E5BB0008E0EC6 /* News.swift in Sources */,
+				22524E482781CDE700DDFE7D /* UserSettings.swift in Sources */,
 				2212AFFB265D8A6400002FC9 /* Nav.swift in Sources */,
 				22FD601A2677942200BF02BF /* Timetable.swift in Sources */,
 			);

--- a/HEG Schedule.xcodeproj/xcuserdata/dietrich.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/HEG Schedule.xcodeproj/xcuserdata/dietrich.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>HEG Schedule.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>HEG-WidgetsExtension.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WidgetExtension.xcscheme_^#shared#^_</key>
 		<dict>

--- a/HEG Schedule/Nav.swift
+++ b/HEG Schedule/Nav.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct Nav: View {
     @State private var selectedView: Int? = 0
     
+    // get the value from the local storage to show SettingsScreen view if value is nil
+    @State private var username = UserDefaults.standard.string(forKey: "name_preference")
+    
     var body: some View {
         NavigationView {
             List{
@@ -18,13 +21,23 @@ struct Nav: View {
                 NavigationLink(destination: News(), tag: 2, selection: $selectedView) {Label("News", systemImage: "network")}
               
                 NavigationLink(destination: VPlan(), tag: 3, selection: $selectedView) {Label("Vertretungsplan", systemImage: "calendar.badge.clock")}
+                
+                NavigationLink(destination: SettingsScreen(), tag: 4, selection: $selectedView) {Label("Einstellungen", systemImage: "gear")}
             }.navigationTitle("HEG Schedule")
         }.onAppear{
             let device = UIDevice.current
             if device.model == "iPad"{
-                self.selectedView = 1
+                if(username == nil) {
+                    self.selectedView = 4
+                } else {
+                    self.selectedView = 1
+                }
             } else {
-                self.selectedView = 0
+                if(username == nil) {
+                    self.selectedView = 4
+                } else {
+                    self.selectedView = 0
+                }
             }
         }
     }

--- a/HEG Schedule/SettingsScreen.swift
+++ b/HEG Schedule/SettingsScreen.swift
@@ -1,0 +1,65 @@
+//
+//  SetupScreen.swift
+//  HEG Schedule
+//
+//  Created by Dietrich Poensgen on 01.01.22.
+//
+
+import SwiftUI
+
+extension Bundle {
+    public var appName: String { getInfo("CFBundleName")  }
+    public var displayName: String {getInfo("CFBundleDisplayName")}
+    public var language: String {getInfo("CFBundleDevelopmentRegion")}
+    public var identifier: String {getInfo("CFBundleIdentifier")}
+    public var copyright: String {getInfo("NSHumanReadableCopyright").replacingOccurrences(of: "\\\\n", with: "\n")}
+    
+    
+    public var appBuild: String { getInfo("CFBundleVersion") }
+    public var appVersionLong: String { getInfo("CFBundleShortVersionString") }
+    public var appVersionShort: String { getInfo("CFBundleShortVersion") }
+    
+    fileprivate func getInfo(_ str: String) -> String { infoDictionary?[str] as? String ?? "⚠️" }
+}
+
+struct SettingsScreen: View {
+    // MARK: following Code gets the Userdefaults from UserSettings.swift
+    @ObservedObject var userSettings = UserSettings()
+    
+
+    // About section variables -> 'ÜBER DIE APP'
+    let appversion = Bundle.main.infoDictionary!["CFBundleShortVersionString"]!
+    
+    var body: some View {
+        VStack {
+                   Form {
+                       Section(header: Text("NUTZERPROFIL")) {
+                           TextField("Benutzername", text: $userSettings.username)
+                           Picker(selection: $userSettings.course, label: Text("Klasse")) {
+                               ForEach(userSettings.courses, id: \.self) { course in
+                                       Text(course)
+                                   }
+                               }
+                       }
+                       Section(header: Text("ÜBER DIE APP")) {
+                           HStack {
+                               Text("Version")
+                               Spacer()
+                               Text(Bundle.main.appVersionLong)
+                           }
+                           HStack {
+                               Text(Bundle.main.copyright)
+                                       .font(.system(size: 10, weight: .thin))
+                                       .multilineTextAlignment(.center)
+                           }
+                       }
+                   }
+               }.navigationTitle("Einstellungen")
+    }
+}
+
+struct SettingsScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsScreen()
+    }
+}

--- a/HEG Schedule/UserSettings.swift
+++ b/HEG Schedule/UserSettings.swift
@@ -1,0 +1,34 @@
+//
+//  UserSettings.swift
+//  HEG Schedule
+//
+//  Created by Dietrich Poensgen on 02.01.22.
+//
+
+import Foundation
+import Combine
+
+class UserSettings: ObservableObject {
+    // MARK: Setting for the username
+    @Published var username: String {
+        didSet {
+            UserDefaults.standard.set(username, forKey: "name_preference")
+        }
+    }
+    
+    // MARK: Setting for the Users class (-> course)
+    @Published var course: String {
+           didSet {
+               UserDefaults.standard.set(course, forKey: "class_preference")
+           }
+       }
+    // available class options
+       public var courses = ["5a", "5b", "5c", "5d", "5e", "6a","6b","6c","6d","6e","7a","7b","7c","7d","8a","8b","8c","8d","9a","9b","9c","9d","10a","10b","10c","10d","11a","11b","11c","11d"]
+    
+    // initialization of the ObservablaObject `UserSettings`
+    init() {
+        self.username = UserDefaults.standard.string(forKey: "name_preference") ?? ""
+        self.course = UserDefaults.standard.object(forKey: "class_preference") as? String ?? "5a"
+    }
+    
+}


### PR DESCRIPTION
This add's the working Settings Screen. The data is provided by the `UserSettings` Observable Object.

## preview
### main settings screen
![settings-main](https://user-images.githubusercontent.com/47633893/148121581-f6de132e-0a90-4e4f-a078-d163af3302da.png)

### class selection
![settings-selection](https://user-images.githubusercontent.com/47633893/148121612-eeb61c27-b0fa-4a3e-85f7-5e4cea01f2f8.png)


